### PR TITLE
Add Module Declaration for Composition API

### DIFF
--- a/lib/module.ts
+++ b/lib/module.ts
@@ -7,6 +7,16 @@ declare module 'vue/types/vue' {
   }
 }
 
+declare module '@nuxt/types' {
+  interface NuxtAppOptions {
+    $stripe: typeof getStripeInstance
+  }
+
+  interface Context {
+    $stripe: typeof getStripeInstance
+  }
+}
+
 // eslint-disable-next-line
 export default function StripeModule(this: any): void {
   const defaults = {


### PR DESCRIPTION
In order to use this.$stripe in the setup method, it needs to be accessible via getContext(). This makes the method accessible when using the nuxt composition api in the following way:

```
<script lang="ts">
export default defineComponent({
  setup() {
    const { $stripe } = useContext()
    
    const checkout = async () => {
    
      const stripe = await $stripe()
      stripe?.redirectToCheckout({
        sessionId: 'someSessionId',
      })
    }
  }
})
</script>
```