### PR TITLE
Adds option to set publishableKey in on instance creation

### DIFF
--- a/lib/module.ts
+++ b/lib/module.ts
@@ -23,10 +23,18 @@ export default function StripeModule(this: any): void {
     i18n: false,
   }
 
+  const publicRuntimeConfig = this.nuxt.options.publicRuntimeConfig
   const options = Object.assign({}, defaults, this.options.stripe)
+
   if (
-    typeof options.publishableKey !== 'string' ||
-    !options.publishableKey.length
+      (
+          typeof options.publishableKey !== 'string' ||
+          !options.publishableKey.length
+      ) &&
+      (
+          typeof publicRuntimeConfig.stripe.publishableKey !== 'string' ||
+          !publicRuntimeConfig.stripe.publishableKey.length
+      )
   ) {
     throw new Error('nuxt-stripejs: publishableKey is required')
   }

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -16,7 +16,7 @@ function delayNextRetry(retryCount: number): Promise<void> {
 }
 
 export async function getStripeInstance(
-  locale?: StripeElementLocale | CheckoutLocale
+  locale?: StripeElementLocale | CheckoutLocale, publishableKey?: string
 ): Promise<Stripe | null> {
   if (!stripe) {
     if (!locale && _isTrue('<%= options.i18n %>')) {
@@ -26,7 +26,7 @@ export async function getStripeInstance(
     let retries = 0
     do {
       try {
-        stripe = await loadStripe('<%= options.publishableKey %>', { locale })
+        stripe = await loadStripe(publishableKey || '<%= options.publishableKey %>', { locale })
       } catch (e) {
         stripe = null
         retries++


### PR DESCRIPTION
Since this package is running on client side only, rebuilding for every change in the nuxt config or environment variable is not necessary.

Using runtimeconfig would be the better way to provide the publishableKey to the getStripeInstance function
https://nuxtjs.org/docs/2.x/directory-structure/nuxt-config#runtimeconfig

I have the feeling that having a factory function for getStripeInstance would be a bit cleaner, but I am not able to get the type configuration working =/

After my changes, I am using it like this:
`const stripe = await $stripe(undefined, $config.stripe.publishableKey)`